### PR TITLE
Add support for PHP 8.5

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.0, 8.1, 8.2, 8.3, 8.4 ]
+        php-version: [ 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 ]
         composer-prefer: [ lowest, dist ]
     steps:
       - uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require-dev": {
         "phpstan/phpstan": "1.12.7",
         "phpstan/phpstan-strict-rules": "1.6.1",
-        "phpunit/phpunit": "9.6.16",
+        "phpunit/phpunit": "9.6.34",
         "squizlabs/php_codesniffer": "3.11.2",
         "symfony/cache": "6.0.19",
         "thecodingmachine/phpstan-strict-rules": "1.0.0"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~8.0.2 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "ext-newrelic": ">=7.5.0",
         "psr/simple-cache": "^3.0",
         "psr/cache": "^3.0"


### PR DESCRIPTION
* Add 8.5.x to the list of explicitly supported PHP minor versions
* Bump minimum PHP version from 8.0.0 to 8.0.2